### PR TITLE
Get correct constructor for numpy arrays

### DIFF
--- a/pyvoro/__init__.py
+++ b/pyvoro/__init__.py
@@ -66,7 +66,7 @@ Output format is a list of cells as follows:
     },
     ... 
   ]"""
-  vector_class = points[0].__class__
+  vector_class = voroplusplus.get_constructor(points[0])
   points = [list(p) for p in points]
   points3d = [p[:] +[0.] for p in points]
   limits3d = [l[:] for l in limits] + [[-z_height, +z_height]]

--- a/pyvoro/voroplusplus.pyx
+++ b/pyvoro/voroplusplus.pyx
@@ -34,10 +34,28 @@ cdef extern from "stdlib.h":
   void free(void *ptr)
   void* malloc(size_t size)
 
+import sys
 import math
 
 class VoronoiPlusPlusError(Exception):
   pass
+
+
+def get_constructor(obj):
+  """
+Input arg format:
+  obj = the object we want to get the constructor for
+  """
+  typ = type(obj)
+
+  # Test if we have a numpy array
+  if hasattr(typ, '__module__'):
+    if typ.__module__ == 'numpy':
+      numpy = sys.modules['numpy']
+      typ = numpy.array
+  
+  return typ
+
 
 def compute_voronoi(points, limits, dispersion, radii=[], periodic=[False]*3):
   """
@@ -76,8 +94,9 @@ Output format is a list of cells as follows:
   cdef int n = len(points), i, j
   cdef double *xs, *ys, *zs, *rs
   cdef void** voronoi_cells
-  vector_class = points[0].__class__
   
+  vector_class = get_constructor(points[0])
+
   periodic = [1 if p else 0 for p in periodic]
   
   # we must make sure we have at least one block, or voro++ will segfault when


### PR DESCRIPTION
When points are parsed as a numpy array, the vertices returned by `compute_voronoi` are empty.

Specifically, using `obj.__class__` to detect type for numpy arrays will result in the empty arrays as their type `<type 'numpy.ndarray'>` is not used for initializing them directly. The `get_constructor` function added to `voroplusplus` checks specifically for a numpy array and returns the factory function, otherwise returns `type(obj)`. 
