### PR TITLE
added manifest file for setup sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include pyvoro/voroplusplus.pyx
+include pyvoro/vpp.h
+include src/*.cc
+include src/*.hh


### PR DESCRIPTION
Recently I tried to install pyvoro via pip and it failed due to not including several files in source distribution. Seems that pypi doesn't add files that are not explicitly mentioned in setup.py to package source - I didn't test setup.py sdist properly, and I'm sorry about that. To add files to package source we need to add MANIFEST.in with names of files to be included in source and that's what this pull request does. I've tested it, and (finally :)) it works as expected.
