### PR TITLE
Fixed relative import problem

### DIFF
--- a/pyvoro/__init__.py
+++ b/pyvoro/__init__.py
@@ -1,4 +1,4 @@
-import voroplusplus
+from . import voroplusplus
 
 def compute_voronoi(points, limits, dispersion, radii=[], periodic=[False]*3):
   """

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from distutils.core import setup, Extension
 
 # fall back to provided cpp file if Cython is not found
 extensions = [
-    Extension("voroplusplus",
+    Extension("pyvoro.voroplusplus",
               sources=["pyvoro/voroplusplus.cpp",
                        "pyvoro/vpp.cpp",
                        "src/voro++.cc"],
@@ -23,12 +23,12 @@ extensions = [
 
 setup(
     name="pyvoro",
-    version="1.3.2",
+    version="1.3.3",
     description="2D and 3D Voronoi tessellations: a python entry point for the voro++ library.",
     author="Joe Jordan",
     author_email="joe.jordan@imperial.ac.uk",
     url="https://github.com/joe-jordan/pyvoro",
-    download_url="https://github.com/joe-jordan/pyvoro/tarball/v1.3.2",
+    download_url="https://github.com/joe-jordan/pyvoro/tarball/v1.3.3",
     packages=["pyvoro",],
     package_dir={"pyvoro": "pyvoro"},
     ext_modules=extensions,


### PR DESCRIPTION
This should fix Issue #8; it builds and installs properly on both Python 2.7 and Python 2.4 on my machine (Arch Linux). Note that this does not put `cythonize` back in; setup.py still simply uses the `voroplusplus.cpp` file already there.
